### PR TITLE
 issue 86: add script to sandbox/Vestcor Data Cleaning for review

### DIFF
--- a/sandbox/Vestcor Data Cleaning/spinnj_issue86.R
+++ b/sandbox/Vestcor Data Cleaning/spinnj_issue86.R
@@ -1,0 +1,44 @@
+# spinnj_issue86.R
+#
+# factorsSPGMI and stocksCRSP do not use official GICS naming conventions in 
+# sector names. In addition, several securities have obvious misspellings in 
+# Sector assignment, resulting in incorrect groupings. This appears to be a 
+# result of human intervention/manual data manipulations after the data
+# were obtained from CRSP and SPGMI.
+#
+
+# load data & create tmp copies
+load("./data/factorsSPGMI.rda")
+load("./data/stocksCRSP.rda")
+factorsSPGMI_tmp <- factorsSPGMI 
+stocksCRSP_tmp <- stocksCRSP
+
+# confirm factorsSPGMI and stocksCRSP have incorrect sectors (misspelled)
+unique(factorsSPGMI_tmp$Sector) # contains 16 sectors with dupes/misspellings
+unique(stocksCRSP_tmp$Sector) # contains 16 sectors with dupes/misspellings
+
+# replacement data as per issue #86 description
+bad_sectors <- unique(factorsSPGMI_tmp$Sector)
+good_sectors <- c("Information Technology","Industrials","Health Care",
+                  "Consumer Staples","Energy","Materials",
+                  "Consumer Discretionary","Communication Services","Utilities",
+                  "Real Estate","Health Care","Financials",
+                  "Consumer Discretionary","Information Technology",
+                  "Consumer Staples","Communication Services")
+sector_table <- data.frame(cbind(bad_sectors,good_sectors))
+colnames(sector_table) <- c("BadSectors","GoodSectors")
+sector_table
+
+# replacements
+factorsSPGMI_tmp$Sector <- sector_table$GoodSectors[match(factorsSPGMI_tmp$Sector,sector_table$BadSectors)]
+stocksCRSP_tmp$Sector <- sector_table$GoodSectors[match(stocksCRSP_tmp$Sector,sector_table$BadSectors)]
+
+# confirm factorsSPGMI and stocksCRSP have correct sectors
+unique(factorsSPGMI_tmp$Sector) # contains 11 sectors with no dupes
+unique(stocksCRSP_tmp$Sector) # contains 11 sectors with no dupes
+
+# save data (not yet run)
+#factorsSPGMI <- factorsSPGMI_tmp
+#stocksCRSP <- stocksCRSP_tmp
+#save(factorsSPGMI,file="./data/factorsSPGMI.rda")
+#save(stocksCRSP,file="./data/stocksCRSP.rda")


### PR DESCRIPTION
Trying this again, one piece at a time (instead of all the changes that were included in the prior PR) to keep things neater and make sure I'm not going in a direction that isn't appreciated.

This pull request does not modify any source data, instead it includes only an R script ./sandbox/Vestcor Data Cleaning/spinnj_issue86.R that outlines my suggestions for fixing the sector names which do not adhere to SPGMI official naming conventions as a result of (I assume) manual data manipulations made by someone historically during the process of trying to merge CRSP with SPGMI data.

This can be reviewed and if this is a good change, the commented code at the end will replace factorsSPGMI and stocksCRSP with versions that have official S&P/MSCI GICS Sector Names for all rows. I did not make any changes to factorsSPGMI or stocksCRSP myself.

If this is accepted, then some other data issues (issues #85 and #73) can also be completed easily in the same fashion.

If this is not accepted, then I'll stop looking into cleaning up factorsSPGMI and stocksCRSP and take a look at the roadmap of issues to get on CRAN instead.
